### PR TITLE
Add DownloadMojmaps task and allow reversing inputs in ChainMappings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
     agent {
         docker {
-            image 'gradlewrapper:latest'
+            image 'gradle:jdk8'
             args '-v gradlecache:/gradlecache'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,25 +9,33 @@ pipeline {
     }
     environment {
         GRADLE_ARGS = '-Dorg.gradle.daemon.idletimeout=5000'
+        DISCORD_WEBHOOK = credentials('forge-discord-jenkins-webhook')
+        DISCORD_PREFIX = "Job: ForgeSPI Branch: ${BRANCH_NAME} Build: #${BUILD_NUMBER}"
+        JENKINS_HEAD = 'https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png'
     }
 
     stages {
-        stage('fetch') {
+        stage('notify_start') {
+            when {
+                not {
+                    changeRequest()
+                }
+            }
             steps {
-                checkout scm
+                discordSend(
+                    title: "${DISCORD_PREFIX} Started",
+                    successful: true,
+                    result: 'ABORTED', //White border
+                    thumbnail: JENKINS_HEAD,
+                    webhookURL: DISCORD_WEBHOOK
+                )
             }
         }
         stage('buildandtest') {
             steps {
                 sh './gradlew ${GRADLE_ARGS} --refresh-dependencies --continue build test'
                 script {
-                    env.MYVERSION = sh(returnStdout: true, script: './gradlew properties -q | grep "version:" | awk \'{print $2}\'').trim()
-                }
-            }
-            post {
-                success {
-                    writeChangelog(currentBuild, 'build/changelog.txt')
-                    archiveArtifacts artifacts: 'build/changelog.txt', fingerprint: false
+                    gradleVersion(this)
                 }
             }
         }
@@ -37,20 +45,34 @@ pipeline {
                     changeRequest()
                 }
             }
-            environment {
-                FORGE_MAVEN = credentials('forge-maven-forge-user')
-            }
             steps {
-                sh './gradlew ${GRADLE_ARGS} publish -PforgeMavenUser=${FORGE_MAVEN_USR} -PforgeMavenPassword=${FORGE_MAVEN_PSW}'
-                sh 'curl --user ${FORGE_MAVEN} http://files.minecraftforge.net/maven/manage/promote/latest/net.minecraftforge.installertools/${MYVERSION}'
+                withCredentials([usernamePassword(credentialsId: 'maven-forge-user', usernameVariable: 'MAVEN_USER', passwordVariable: 'MAVEN_PASSWORD')]) {
+                    withGradle {
+                        sh './gradlew ${GRADLE_ARGS} publish'
+                    }
+                }
+            }
+            post {
+                success {
+                    build job: 'filegenerator', parameters: [string(name: 'COMMAND', value: "promote ${env.MYGROUP}:${env.MYARTIFACT} ${env.MYVERSION} latest")], propagate: false, wait: false
+                }
             }
         }
     }
     post {
         always {
-            archiveArtifacts artifacts: 'build/libs/**/*.jar', fingerprint: true
-            //junit 'build/test-results/*/*.xml'
-            //jacoco sourcePattern: '**/src/*/java'
+            script {
+                if (env.CHANGE_ID == null) { // This is unset for non-PRs
+                    discordSend(
+                        title: "${DISCORD_PREFIX} Finished ${currentBuild.currentResult}",
+                        description: '```\n' + getChanges(currentBuild) + '\n```',
+                        successful: currentBuild.resultIsBetterOrEqualTo("SUCCESS"),
+                        result: currentBuild.currentResult,
+                        thumbnail: JENKINS_HEAD,
+                        webhookURL: DISCORD_WEBHOOK
+                    )
+                }
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 
 repositories {
     mavenCentral()
-    maven { url 'https://files.minecraftforge.net/maven/' }
+    maven { url 'https://maven.minecraftforge.net/' }
 }
 
 license {
@@ -91,12 +91,15 @@ publishing {
     }
     repositories {
         maven {
-            if (project.hasProperty('forgeMavenPassword')) {
-                credentials {
-                    username project.properties.forgeMavenUser
-                    password project.properties.forgeMavenPassword
+            if (System.env.MAVEN_USER) {
+                url 'https://maven.minecraftforge.net/'
+                authentication {
+                    basic(BasicAuthentication)
                 }
-                url 'http://files.minecraftforge.net/maven/manage/upload'
+                credentials {
+                    username = System.env.MAVEN_USER ?: 'not'
+                    password = System.env.MAVEN_PASSWORD ?: 'set'
+                }
             } else {
                 url 'file://' + rootProject.file('repo').getAbsolutePath()
             }

--- a/src/main/java/net/minecraftforge/installertools/ChainMappings.java
+++ b/src/main/java/net/minecraftforge/installertools/ChainMappings.java
@@ -41,8 +41,10 @@ public class ChainMappings extends Task {
     public void process(String[] args) throws IOException {
         OptionParser parser = new OptionParser();
         OptionSpec<File> leftO = parser.accepts("left").withRequiredArg().ofType(File.class).required();
+        OptionSpec<Void> reverseLeftO = parser.accepts("reverse-left");
         OptionSpec<String> leftNamesO = parser.accepts("left-names").withRequiredArg().ofType(String.class);
         OptionSpec<File> rightO = parser.accepts("right").withRequiredArg().ofType(File.class).required();
+        OptionSpec<Void> reverseRightO = parser.accepts("reverse-right");
         OptionSpec<String> rightNamesO = parser.accepts("right-names").withRequiredArg().ofType(String.class);
         OptionSpec<File> outputO = parser.accepts("output").withRequiredArg().ofType(File.class).required();
 
@@ -67,8 +69,10 @@ public class ChainMappings extends Task {
             final boolean params  = !selective || options.has(paramsO);
 
             log("Left:    " + left);
+            log("         Reversed=" + options.has(reverseLeftO));
             log("         " + (leftNames == null ? "null" : options.valueOf(leftNamesO)));
             log("Right:   " + right);
+            log("         Reversed=" + options.has(reverseRightO));
             log("         " + (rightNames == null ? "null" : options.valueOf(rightNamesO)));
             log("Classes: " + classes);
             log("Fields:  " + fields);
@@ -89,7 +93,11 @@ public class ChainMappings extends Task {
 
 
             IMappingFile leftM = leftNames == null ? IMappingFile.load(left) : INamedMappingFile.load(left).getMap(leftNames[0], leftNames[1]);
+            if (options.has(reverseLeftO))
+                leftM = leftM.reverse();
             IMappingFile rightM = rightNames == null ? IMappingFile.load(right) : INamedMappingFile.load(right).getMap(rightNames[0], rightNames[1]);
+            if (options.has(reverseRightO))
+                rightM = rightM.reverse();
             IMappingFile outputM = leftM.rename(makeRenamer(rightM, classes, fields, methods, params));
 
             outputM.write(output.toPath(), IMappingFile.Format.TSRG2, false);

--- a/src/main/java/net/minecraftforge/installertools/DownloadMojmaps.java
+++ b/src/main/java/net/minecraftforge/installertools/DownloadMojmaps.java
@@ -1,3 +1,21 @@
+/*
+ * InstallerTools
+ * Copyright (c) 2019-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.minecraftforge.installertools;
 
 import com.google.gson.Gson;

--- a/src/main/java/net/minecraftforge/installertools/DownloadMojmaps.java
+++ b/src/main/java/net/minecraftforge/installertools/DownloadMojmaps.java
@@ -1,0 +1,70 @@
+package net.minecraftforge.installertools;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import net.minecraftforge.installertools.util.ManifestJson;
+import net.minecraftforge.installertools.util.VersionJson;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.file.Files;
+
+public class DownloadMojmaps extends Task {
+    private static final String MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
+    private static final Gson GSON = new GsonBuilder().create();
+
+    @Override
+    public void process(String[] args) throws IOException {
+        OptionParser parser = new OptionParser();
+        OptionSpec<String> versionO = parser.accepts("version").withRequiredArg().ofType(String.class).required();
+        OptionSpec<String> sideO = parser.accepts("side").withRequiredArg().ofType(String.class).required();
+        OptionSpec<File> outputO = parser.accepts("output").withRequiredArg().ofType(File.class).required();
+
+        try {
+            OptionSet options = parser.parse(args);
+
+            String mcversion = options.valueOf(versionO);
+            String side = options.valueOf(sideO);
+            File output = options.valueOf(outputO);
+
+            log("MC Version: " + mcversion);
+            log("Side:       " + side);
+            log("Output:     " + output);
+
+            if (output.exists() && !output.delete())
+                error("Could not delete output file: " + output);
+
+            if (!output.getParentFile().exists() && !output.getParentFile().mkdirs())
+                error("Could not make output folders: " + output.getParentFile());
+
+            try (InputStream manIn = new URL(MANIFEST_URL).openStream()) {
+                URL url = GSON.fromJson(new InputStreamReader(manIn), ManifestJson.class).getUrl(mcversion);
+                if (url == null)
+                    error("Missing version from manifest: " + mcversion);
+
+                try (InputStream verIn = url.openStream()) {
+                    VersionJson json = VersionJson.load(verIn);
+                    if (json == null)
+                        error("Missing Minecraft version JSON from URL " + url);
+
+                    VersionJson.Download download = json.downloads.get(side + "_mappings");
+                    if (download == null || download.url == null)
+                        error("Missing download info for " + side + " mappings");
+
+                    Files.copy(download.url.openStream(), output.toPath());
+                    log("Downloaded Mojang mappings for " + mcversion);
+                }
+            }
+        } catch (OptionException e) {
+            parser.printHelpOn(System.out);
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/installertools/Tasks.java
+++ b/src/main/java/net/minecraftforge/installertools/Tasks.java
@@ -28,7 +28,8 @@ public enum Tasks {
     SRG_TO_MCP(SrgMcpRenamer::new),
     EXTRACT_INHERITANCE(ExtractInheritance::new),
     CHAIN_MAPPING(ChainMappings::new),
-    MERGE_MAPPING(MergeMappings::new);
+    MERGE_MAPPING(MergeMappings::new),
+    DOWNLOAD_MOJMAPS(DownloadMojmaps::new);
 
     private Supplier<? extends Task> supplier;
 

--- a/src/main/java/net/minecraftforge/installertools/util/ManifestJson.java
+++ b/src/main/java/net/minecraftforge/installertools/util/ManifestJson.java
@@ -1,3 +1,21 @@
+/*
+ * InstallerTools
+ * Copyright (c) 2019-2021.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.minecraftforge.installertools.util;
 
 import java.net.URL;

--- a/src/main/java/net/minecraftforge/installertools/util/ManifestJson.java
+++ b/src/main/java/net/minecraftforge/installertools/util/ManifestJson.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.installertools.util;
+
+import java.net.URL;
+
+public class ManifestJson {
+    public VersionInfo[] versions;
+
+    public static class VersionInfo {
+        public String id;
+        public URL url;
+    }
+
+    public URL getUrl(String version) {
+        if (version == null) {
+            return null;
+        }
+        for (VersionInfo info : versions) {
+            if (version.equals(info.id)) {
+                return info.url;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/installertools/util/VersionJson.java
+++ b/src/main/java/net/minecraftforge/installertools/util/VersionJson.java
@@ -50,10 +50,14 @@ public class VersionJson {
 
     public static VersionJson load(File path) {
         try (InputStream stream = new FileInputStream(path)) {
-            return GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), VersionJson.class);
+            return load(stream);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static VersionJson load(InputStream stream) {
+        return GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), VersionJson.class);
     }
 
     public Arguments arguments;


### PR DESCRIPTION
DownloadMojmaps is useful for downloading the Mojang obfuscation mappings file as a post processor in the installer setup, which will be necessary going forward in 1.17+ because MCPConfig exports have SRG classnames. This can be used in conjunction with ChainMappings (when reversing the right side) to produce a merged SRG mapping file with Mojmap classnames.