### PR TITLE
Support deobf of arbitrarily nested jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /repo/
 /.settings/
 /bin/
+/out/
 .classpath
 .project
 *.lzma


### PR DESCRIPTION
This supports deobf of arbitrarily nested jars to support `fg.deobf` of jars using JIJ.
Tested with SRG methods in a jar in a jar in a jar and worked fine on all 3 layers.