### PR TITLE
Add soft-fail when class bytecode is processed by SrgMcpRenamer

### DIFF
--- a/src/main/java/net/minecraftforge/installertools/SrgMcpRenamer.java
+++ b/src/main/java/net/minecraftforge/installertools/SrgMcpRenamer.java
@@ -164,10 +164,15 @@ public class SrgMcpRenamer extends Task {
     private void processClass(final ZipEntry ein, final ZipInputStream zin, final ZipOutputStream zout, final Remapper remapper) throws IOException {
         byte[] data = Utils.toByteArray(zin);
 
-        ClassReader reader = new ClassReader(data);
-        ClassWriter writer = new ClassWriter(0);
-        reader.accept(new ClassRemapper(writer, remapper), 0);
-        data = writer.toByteArray();
+        try {
+            ClassReader reader = new ClassReader(data);
+            ClassWriter writer = new ClassWriter(0);
+            reader.accept(new ClassRemapper(writer, remapper), 0);
+            data = writer.toByteArray();
+        }
+        catch(Throwable e) {
+            log(String.format("Could not process class: %s, skipping", e.getLocalizedMessage()));
+        }
 
         zout.putNextEntry(makeNewEntry(ein));
         zout.write(data);


### PR DESCRIPTION
This prevents the tool from crashing/Gradle build from failing when the `SrgMcpRenamer` encounters a class it cannot process. `ClassReader` throws an exception if the class file version is not acceptible.
This is especially useful if there's non-mod shadow dependencies which are built externally with a different target class file version.